### PR TITLE
Compact field layout + simplified status chip + README install guide

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main, master]
   pull_request:
-    branches: [master]
+    branches: [main, master]
 
 jobs:
   lint:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Normalized delimiter variants in auto-map (`Store ID`, `store_id`, `store-id`, `StoreID` all match the same canonical field).
 - CI Node.js version bumped to 24.
 - README rewritten to reflect the current installation flow (template-copy distribution) and feature set.
+- Field mapping rows switched to a compact 2-column grid (label left, select right) with a fixed 110px label column so all fields line up vertically.
+- Simplified the readiness status chip from "✓ Lat/Lng ready" / "✓ Address ready" variants to a single "✓ Ready".
+- README Installation section rewritten with a detailed step-by-step first-run guide (copy link, Make a copy, waiting for the Extensions menu, approving the "unverified app" warning, entering the API key) and a new "Updating to a newer version" section.
 
 ### Fixed
 

--- a/README.MD
+++ b/README.MD
@@ -8,19 +8,60 @@ https://docs.placekey.io/
 
 ## Installation
 
-The addon is distributed as a Google Sheet template with the script bound to it. Open this link to get your own copy with the addon pre-installed:
+The addon is distributed as a Google Sheet template with the script bound to it. There is no Marketplace install — installation is by making your own copy.
+
+### 1. Open the copy link
 
 https://docs.google.com/spreadsheets/d/1a7GQY0Qx_xjGqeu-kgyx_TNAtSTCR2tqL0scRNgtS3o/copy
 
-Click **Make a copy** — the **Placekey Add-on** menu will appear under **Extensions** after the sheet reloads. On first use, Google will prompt you to authorize the addon.
+You must be signed in to a Google account. The link brings you to a **Copy document** dialog.
+
+### 2. Click "Make a copy"
+
+A new spreadsheet named **Copy of Placekey Starter** appears in your own Google Drive. Rename it to whatever you like — it's yours now.
+
+### 3. Wait for the Extensions menu to populate
+
+Open the **Extensions** menu. It may take **10–30 seconds** on first open for **Placekey Add-on** to appear. If you don't see it, close the menu and open it again, or refresh the sheet.
+
+### 4. First run — authorize the addon
+
+Go to **Extensions → Placekey Add-on → Generate Placekeys**. Google prompts you to authorize.
+
+- Click **Continue** → pick your account
+- You'll see a warning: _"Google hasn't verified this app"_. This is expected because the addon is not distributed via the Workspace Marketplace.
+- Click **Advanced** → **Go to Placekey Add-on (unsafe)**
+- Review the requested permissions (Sheets access, external URL requests for the Placekey API) and click **Allow**
+
+You only do this once per copy.
+
+### 5. Enter your API key
+
+A dialog appears asking for your Placekey API key. If you don't have one, [get a free key](https://dev.placekey.io/). Your key is stored per-user in Apps Script's secure UserProperties — it does not live in the sheet and is not visible to anyone else who opens a copy.
+
+### 6. Map columns and generate
+
+The sidebar opens. See [Usage](#usage) below.
+
+---
 
 ## Usage
 
-1. Open the copied sheet and import your address or POI data. Or click **Fill with sample data** to experiment.
-2. **Extensions → Placekey Add-on → Generate Placekeys**.
-3. Enter your Placekey API key. If you don't have one, get a free API key at https://dev.placekey.io/.
-4. Map your spreadsheet columns to the API fields. Most common column headers are auto-mapped.
-5. Click **Generate Placekeys**.
+1. **Have your data in the sheet.** Header row on row 1 (e.g. `Name`, `Street Address`, `City`, `State`, `Zip`, `Country`). Data rows beneath. Or click **Fill with sample data** in the sidebar to experiment.
+2. **Open the sidebar** if it's not already open: **Extensions → Placekey Add-on → Generate Placekeys**.
+3. **Map each API field to one of your columns.** Common column headers are auto-mapped (see Features). A green dot means the field is mapped; gray means unmapped; red means two fields point to the same column.
+4. **Check the return fields** you want appended. `Placekey` is always returned. `Confidence Level` is checked by default. Enable others like `Geocode`, `GERS`, `UPI` as needed. Your selection is saved per-user across all sheets.
+5. **Click Generate.** Progress is shown in the sidebar. Results are written into columns appended to the right of your data (or reused if headers like `Placekey` already exist).
+
+### Updating to a newer version
+
+Because each user has their own copy, existing copies do not auto-update. To get a newer version:
+
+- Make a **fresh copy** from the link above
+- Copy your data into the new sheet (or re-import)
+- Authorize once again
+
+The copy link is stable — it always serves the latest version.
 
 ## Features
 

--- a/Stylesheet.html
+++ b/Stylesheet.html
@@ -110,46 +110,38 @@
     margin: 16px 0 4px;
   }
 
-  /* Field */
+  /* Field (compact row layout — label left, select right) */
   .field {
-    margin-top: 10px;
-  }
-  .field__row {
-    display: flex;
+    display: grid;
+    grid-template-columns: 110px 1fr;
     align-items: center;
-    gap: 6px;
-    margin-bottom: 4px;
+    column-gap: 8px;
+    margin-top: 4px;
   }
   .field__dot {
-    width: 8px;
-    height: 8px;
+    display: inline-block;
+    vertical-align: middle;
+    width: 7px;
+    height: 7px;
     border-radius: 50%;
     background: var(--pk-border);
+    margin-right: 4px;
     transition: background 120ms ease;
-    flex-shrink: 0;
   }
   .field__label {
     font-size: 12px;
     font-weight: 500;
     color: var(--pk-text);
-    flex: 1;
     cursor: help;
-  }
-  .field__example {
-    font-size: 11px;
-    color: var(--pk-text-subtle);
-    margin-top: 2px;
-    font-style: italic;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .field[data-state="mapped"] .field__dot {
     background: var(--pk-success);
   }
   .field[data-state="conflict"] .field__dot {
     background: var(--pk-danger);
-  }
-  .field[data-state="mapped"] .field__example,
-  .field[data-state="conflict"] .field__example {
-    display: none;
   }
 
   /* Form controls */

--- a/mapColumns.html
+++ b/mapColumns.html
@@ -38,75 +38,43 @@
         </div>
 
         <div class="field" data-field="location_name">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="location_name" class="field__label" title="Business or place name, e.g. Twin Peaks Petroleum">Location Name</label>
-          </div>
+          <label for="location_name" class="field__label" title="Business or place name, e.g. Twin Peaks Petroleum"> <span class="field__dot" aria-hidden="true"></span> Location Name </label>
           <select id="location_name" class="selectCols"></select>
-          <div class="field__example">e.g. Twin Peaks Petroleum</div>
         </div>
 
         <div class="field" data-field="street_address">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="street_address" class="field__label" title="Street address, e.g. 598 Portola Dr">Street Address</label>
-          </div>
+          <label for="street_address" class="field__label" title="Street address, e.g. 598 Portola Dr"> <span class="field__dot" aria-hidden="true"></span> Street Address </label>
           <select id="street_address" class="selectCols"></select>
-          <div class="field__example">e.g. 598 Portola Dr</div>
         </div>
 
         <div class="field" data-field="city">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="city" class="field__label" title="City or town">City</label>
-          </div>
+          <label for="city" class="field__label" title="City or town"> <span class="field__dot" aria-hidden="true"></span> City </label>
           <select id="city" class="selectCols"></select>
-          <div class="field__example">e.g. San Francisco</div>
         </div>
 
         <div class="field" data-field="region">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="region" class="field__label" title="US state · Canadian province · UK county">Region</label>
-          </div>
+          <label for="region" class="field__label" title="US state · Canadian province · UK county"> <span class="field__dot" aria-hidden="true"></span> Region </label>
           <select id="region" class="selectCols"></select>
-          <div class="field__example">state, province, or county</div>
         </div>
 
         <div class="field" data-field="postal_code">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="postal_code" class="field__label" title="US: 94131 · Canada: M5V 3A8 · UK: SW1A 1AA">Postal Code</label>
-          </div>
+          <label for="postal_code" class="field__label" title="US: 94131 · Canada: M5V 3A8 · UK: SW1A 1AA"> <span class="field__dot" aria-hidden="true"></span> Postal Code </label>
           <select id="postal_code" class="selectCols"></select>
-          <div class="field__example">zip, postal code, or postcode</div>
         </div>
 
         <div class="field" data-field="latitude">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="latitude" class="field__label" title="Latitude in decimal degrees">Latitude</label>
-          </div>
+          <label for="latitude" class="field__label" title="Latitude in decimal degrees"> <span class="field__dot" aria-hidden="true"></span> Latitude </label>
           <select id="latitude" class="selectCols"></select>
-          <div class="field__example">e.g. 37.7371</div>
         </div>
 
         <div class="field" data-field="longitude">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="longitude" class="field__label" title="Longitude in decimal degrees">Longitude</label>
-          </div>
+          <label for="longitude" class="field__label" title="Longitude in decimal degrees"> <span class="field__dot" aria-hidden="true"></span> Longitude </label>
           <select id="longitude" class="selectCols"></select>
-          <div class="field__example">e.g. -122.44283</div>
         </div>
 
         <div class="field" data-field="iso_country_code">
-          <div class="field__row">
-            <span class="field__dot" aria-hidden="true"></span>
-            <label for="iso_country_code" class="field__label" title="ISO 3166-1 alpha-2 code: US, CA, GB">Country</label>
-          </div>
+          <label for="iso_country_code" class="field__label" title="ISO 3166-1 alpha-2 code: US, CA, GB"> <span class="field__dot" aria-hidden="true"></span> Country </label>
           <select id="iso_country_code" class="selectCols"></select>
-          <div class="field__example">ISO code, e.g. US</div>
         </div>
 
         <details class="disclosure" id="disclosure-returns" open>
@@ -496,8 +464,7 @@
         // Check each minimum set
         for (const set of MINIMUM_INPUTS) {
           if (set.every((k) => mapped.includes(k))) {
-            if (set.length === 2) return { kind: "ready", text: "✓ Lat/Lng ready" };
-            return { kind: "ready", text: "✓ Address ready" };
+            return { kind: "ready", text: "✓ Ready" };
           }
         }
         // Not yet satisfied — compute the smallest gap


### PR DESCRIPTION
## Summary

- **Compact field layout** — each mapping row is now a 2-column grid (label left, select right) with a fixed 110px label column. Eliminates the separate label-row per field. Saves ~15px × 8 fields ≈ 120px of vertical space; all selects line up cleanly on their left edge.
- **Simplified status chip** — "✓ Lat/Lng ready" / "✓ Address ready" collapse to just "✓ Ready". Which specific minimum set is satisfied doesn't help the user — they just need to know Generate is enabled.
- **README install guide** — rewrote Installation as a numbered 6-step first-run flow (copy link → Make a copy → wait for Extensions menu → authorize the "unverified app" warning → enter API key → map + generate). Added "Updating to a newer version" section explaining the re-copy flow.
- **CHANGELOG** entries under `[Unreleased] → Changed`.

## Before / after

Before (8 fields × ~50px row = ~400px):

```
● Location Name
[Name              ▼]
e.g. Twin Peaks Petroleum

● Street Address
[Street Address    ▼]
...
```

After (8 fields × ~36px row = ~288px):

```
● Location Name    [Name              ▼]
● Street Address   [Street Address    ▼]
● City             [City              ▼]
● Region           [State             ▼]
● Postal Code      [Zip code          ▼]
● Latitude         [Latitude          ▼]
● Longitude        [Longitude         ▼]
● Country          [Country           ▼]
```

## Test plan

- [ ] Open template-sheet copy, verify sidebar renders with all 8 select boxes aligned on their left edge
- [ ] Auto-map populates green dots on a sheet with familiar headers (Name, Street Address, City, State, Zip, Lat, Lng, Country)
- [ ] Status chip shows "Map columns to begin" → "Need <fields>" → "✓ Ready" as mappings become sufficient
- [ ] Status chip shows "Duplicate column mapping" (red) when two fields point at the same column
- [ ] "Generate" button disables/enables correctly based on status
- [ ] Fresh copy of the template follows the README steps without friction
- [ ] CI: lint + format + 140 tests all pass