### PR TITLE
Marketplace prep: scope guard, asset specs, privacy section

### DIFF
--- a/marketing/marketplace/README.md
+++ b/marketing/marketplace/README.md
@@ -1,0 +1,50 @@
+# Marketplace listing assets
+
+Source-of-truth specs for the Google Workspace Marketplace listing of
+**Placekey for Google Sheets**. Design produces these files; engineering
+uploads them in the Google Cloud Console.
+
+## Icons (PNG, 1:1 square, transparent or solid background)
+
+Generate all sizes from a single source SVG so they stay aligned.
+
+| File | Size | Where it's used |
+|---|---|---|
+| `icon-32.png` | 32×32 | Marketplace Store Listing — small icon (required) |
+| `icon-48.png` | 48×48 | Marketplace Store Listing — small web-app icon (required, web app) |
+| `icon-96.png` | 96×96 | Marketplace SDK App Configuration — web-app icon (required, web app) |
+| `icon-120.png` | 120×120 | Google Auth platform → Branding → App logo (required for brand verification) |
+| `icon-128.png` | 128×128 | Marketplace Store Listing — large icon (required) |
+
+## Promo banner (optional)
+
+| File | Size | Notes |
+|---|---|---|
+| `banner-220x140.png` | 220×140 | Featured/category cards in the Marketplace |
+
+## Screenshots (PNG, 1280×800 preferred)
+
+Full-bleed (no padding). Take from the actual standalone deployment after
+migration — never from a copy-template build (different look-and-feel).
+
+| File | Caption |
+|---|---|
+| `screenshot-1-mapping.png` | Map your columns to Placekey API fields with auto-detection. |
+| `screenshot-2-progress.png` | Generate Placekeys for thousands of rows in batches. |
+| `screenshot-3-results.png` | Placekey, Confidence, and Geocode columns appended to your data. |
+| `screenshot-4-fields.png` | Choose exactly which return fields you need. |
+| `screenshot-5-apikey.png` | Free Placekey API key — get one in 30 seconds. |
+
+3–5 screenshots are required; the captions above pair with the listing copy.
+
+## Optional
+
+- `promo.mp4` / YouTube URL — promotional video (optional; can boost conversion)
+
+## Naming and storage
+
+- All files lowercase, hyphenated, with explicit pixel dimensions for
+  unambiguous size tracking.
+- Source SVGs (icon source, screenshot mockups) live alongside their PNG
+  exports under `marketing/marketplace/source/`.
+- Re-export rather than hand-edit the PNGs when the brand changes.

--- a/marketing/privacy-policy-addon-section.md
+++ b/marketing/privacy-policy-addon-section.md
@@ -1,0 +1,62 @@
+# Privacy policy — Placekey for Google Sheets add-on section
+
+Paste the section below into `https://www.placekey.io/privacy-policy`
+(or wherever the canonical privacy policy lives). The Marketplace
+reviewer reads this section explicitly during review; the language is
+calibrated to satisfy the Google API Services User Data Policy
+(including **Limited Use**) without padding.
+
+When the privacy URL changes, update **Google Auth platform → Branding →
+Privacy policy link** and **Marketplace SDK Store Listing → Privacy
+policy URL** to match.
+
+---
+
+## Placekey for Google Sheets Add-on
+
+The Placekey for Google Sheets add-on's use and transfer of information
+received from Google APIs adhere to the
+[Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy),
+including the **Limited Use** requirements.
+
+The add-on accesses Google user data only as needed to provide its
+user-facing functionality. We do not transfer this data to third parties
+except as needed to provide the feature, do not use it to serve
+advertisements, and do not allow humans to read it except with your
+explicit consent or as needed for security purposes. Specifically:
+
+- **Spreadsheet contents**: The add-on reads address, location, and
+  identifier columns from the spreadsheet you have open when you invoke
+  it, transmits those rows to the Placekey API at
+  `https://api.placekey.io/v1/placekeys` over HTTPS to obtain Placekey
+  identifiers, and writes the returned identifiers back into your
+  spreadsheet. The add-on uses the `spreadsheets.currentonly` OAuth
+  scope, which limits its access to the single document you have open.
+- **Your Placekey API key**: Stored in Google's per-user Apps Script
+  `UserProperties` storage. It is bound to your Google account and is
+  not visible to anyone else, including other collaborators on the same
+  spreadsheet. The API key is never logged, shared with third parties,
+  or transmitted anywhere except to the Placekey API as the `apikey`
+  HTTP header.
+- **Column mappings, preferences, and transient progress status**:
+  Stored in Apps Script's `UserProperties` (cross-spreadsheet
+  preferences and learned aliases) and `DocumentProperties`
+  (per-spreadsheet column mappings and progress status messages). These
+  are kept on Google's servers under your Google account and are never
+  transmitted off-device by the add-on.
+- **Operational logs**: Unhandled errors are logged to Google Cloud
+  Logging under the developer's GCP project (function names, file
+  paths, and line numbers — no spreadsheet contents).
+
+The add-on does not access any other Google data — no Drive files, no
+Gmail, no Calendar, no Contacts. The add-on does not retain copies of
+your spreadsheet data. The Placekey API processes addresses and
+locations as described in
+[Placekey's main privacy policy](https://www.placekey.io/privacy-policy).
+
+**Deleting your data**: To revoke the add-on's access at any time, visit
+your [Google Account permissions](https://myaccount.google.com/permissions).
+UserProperties and DocumentProperties stored under your Google account
+become inaccessible to the add-on once access is revoked. To request
+deletion of any data held by the Placekey API, contact
+[support@placekey.io](mailto:support@placekey.io).

--- a/test/manifest.test.mjs
+++ b/test/manifest.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const manifest = JSON.parse(readFileSync(join(repoRoot, "appsscript.json"), "utf8"));
+
+// The exact scope set the Marketplace listing was approved against.
+// If you change this list you MUST also update, in lockstep:
+//   - Google Auth platform → Data Access (in the GCP console)
+//   - Workspace Marketplace SDK → App Configuration → OAuth scopes
+// Mismatch is the most common Marketplace-review failure mode.
+const APPROVED_SCOPES = [
+  "https://www.googleapis.com/auth/spreadsheets.currentonly",
+  "https://www.googleapis.com/auth/script.external_request",
+  "https://www.googleapis.com/auth/script.container.ui",
+];
+
+describe("appsscript.json manifest", () => {
+  it("declares exactly the approved OAuth scopes", () => {
+    expect([...manifest.oauthScopes].sort()).toEqual([...APPROVED_SCOPES].sort());
+  });
+
+  it("does not request the broader spreadsheets scope", () => {
+    expect(manifest.oauthScopes).not.toContain("https://www.googleapis.com/auth/spreadsheets");
+  });
+
+  it("does not request any Drive scopes", () => {
+    const driveScopes = manifest.oauthScopes.filter((s) => s.includes("/auth/drive"));
+    expect(driveScopes).toEqual([]);
+  });
+
+  it("uses the V8 runtime", () => {
+    expect(manifest.runtimeVersion).toBe("V8");
+  });
+});


### PR DESCRIPTION
## Summary

Three local-only artifacts that don't require Google Cloud access. They lock in the publishing-plan invariants and pre-stage content the Placekey team needs to drop into the website and design pipeline.

- **`test/manifest.test.mjs`** — locks the OAuth scope set to the three approved scopes (`spreadsheets.currentonly`, `script.external_request`, `script.container.ui`) and asserts no `spreadsheets` or Drive scopes creep in. Catches the most common Marketplace-review failure mode (manifest scopes drifting from the Google Auth platform Data Access tab or the Marketplace SDK App Configuration) before it reaches Google.
- **`marketing/marketplace/README.md`** — concrete spec for the design team: required icon sizes (32, 48, 96, 120, 128), banner, screenshot dimensions/captions, and a naming convention.
- **`marketing/privacy-policy-addon-section.md`** — paste-ready content for the Placekey privacy-policy page with explicit **Limited Use** language the Marketplace reviewer looks for.

## Test plan

- [x] `npm test` (144/144 passing — 4 new manifest tests)
- [x] Spellcheck clean on new files
- [ ] Design team produces icons matching `marketing/marketplace/README.md`
- [ ] Privacy section merged onto the public Placekey privacy-policy page

## Out of scope (requires Google Cloud access)

- Creating the standalone Apps Script project
- Configuring Google Auth platform / Marketplace SDK
- Domain verification in Search Console
- Submitting for review