### PR TITLE
Help panel link cleanup + support email

### DIFF
--- a/Help.html
+++ b/Help.html
@@ -10,8 +10,6 @@
       <h2 class="type-h2">Questions About Placekey?</h2>
 
       <nav>
-        <!-- <a class="btn block w-full mt-20" href="https://www.placekey.io/community" target="_blank" rel="noopener">Join the Placekey Community on Slack</a> -->
-        <a class="btn block w-full mt-20" href="https://assets.website-files.com/5f08ccbb93b299154d34ef7f/5f781dacb8dbcb6d2944a8e0_Why%20Placekey%20-%20Technical%20White%20Paper%20V3.pdf" target="_blank" rel="noopener">Read the Placekey Whitepaper</a>
         <a class="btn block w-full mt-20" href="https://docs.placekey.io/" target="_blank" rel="noopener">View the API Docs</a>
         <a class="btn block w-full mt-20" href="https://www.placekey.io/feedback" target="_blank" rel="noopener">Give us feedback</a>
       </nav>

--- a/marketing/listing-copy.md
+++ b/marketing/listing-copy.md
@@ -56,7 +56,7 @@ end users.
 > details.
 >
 > **Support**: Documentation at
-> [docs.placekey.io](https://docs.placekey.io). For help, contact
+> [docs.placekey.io](https://docs.placekey.io). For help, email
 > [support@placekey.io](mailto:support@placekey.io).
 
 ## Screenshot captions
@@ -105,7 +105,7 @@ To test:
 | Languages | English |
 | Developer name | Placekey |
 | Developer website | https://placekey.io |
-| Developer email | (Placekey shared developer-contact email) |
+| Developer email | support@placekey.io |
 | Privacy policy URL | https://www.placekey.io/privacy-policy |
-| Terms of service URL | (Placekey ToS URL, optional) |
-| Support URL | (Placekey support URL, required, no auth wall) |
+| Terms of service URL | https://www.placekey.io/terms-of-service |
+| Support URL | mailto:support@placekey.io (Marketplace accepts mailto for the Support URL field) |

--- a/setKey.html
+++ b/setKey.html
@@ -22,7 +22,7 @@
       </div>
 
       <div class="footer mt-25">
-        <a class="text-black" href="https://placekey.io/faq" target="_blank" rel="noopener">FAQ</a>
+        <a class="text-black" href="https://www.placekey.io/faq" target="_blank" rel="noopener">FAQ</a>
         <a id="getApi" class="btn ml-15" href="https://dev.placekey.io/" target="_blank" rel="noopener">Get a Free API Key</a>
         <button id="finishSetup" class="btn-solid ml-15" onclick="submitApiKey()">Finish Setup</button>
       </div>


### PR DESCRIPTION
## Summary

- **`Help.html`**: removed the Whitepaper link (hosted on `assets.website-files.com` Webflow CDN, not first-party — Marketplace reviewers prefer first-party hosts) and the commented-out Slack-community link.
- **`setKey.html`**: normalized the FAQ URL to `www.placekey.io/faq` for consistency with the rest of the panel links and the OAuth Authorized Domains list.
- **`marketing/listing-copy.md`**: filled in `support@placekey.io` as the canonical support/developer contact, and the existing `placekey.io/terms-of-service` URL.

## Verified

- All remaining links return 200 with a real browser User-Agent.
- `npm test` 144/144, format check clean.

## Note

I couldn't find any GitHub link in any panel — searched all HTML files for `github` case-insensitively. If you can point me at where you saw it (screenshot or link text), happy to remove it in a follow-up.